### PR TITLE
fix(gulp-sharp): update return value for `gulpPlugin` utility method

### DIFF
--- a/plugins/gulp-sharp/src/utils/plugin.js
+++ b/plugins/gulp-sharp/src/utils/plugin.js
@@ -47,20 +47,17 @@ function transformStream(transformer) {
 export function gulpPlugin(name, onFile) {
   return transformStream((file) => {
     if (file.isNull() || file.isDirectory()) {
-      return file;
+      return Promise.resolve(file);
     }
 
     if (file.isStream()) {
-      throw new PluginError(name, "Streaming not supported");
+      return Promise.reject(new PluginError(name, "Streaming not supported"));
     }
 
     try {
       return onFile(file);
     } catch (error) {
-      throw new PluginError(name, error, {
-        fileName: file.path,
-        showStack: true,
-      });
+      return Promise.reject(new PluginError(name, error, { fileName: file.path, showStack: true }));
     }
   });
 }


### PR DESCRIPTION
The `transformer` function passed to `transformStream` method MUST always return a `Promise` and it was not the case when handling `null` files or directories.