### PR TITLE
chore: add `rollup` group to Dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -27,3 +27,7 @@ updates:
       babel:
         patterns:
           - "@babel/*"
+      rollup:
+        patterns:
+          - "rollup"
+          - "@rollup/*"


### PR DESCRIPTION
This PR makes a minor update to the `.github/dependabot.yml` configuration, adding support for tracking updates to `rollup` and related packages.

* Added a new `rollup` group under `updates:` in `.github/dependabot.yml`, including patterns for both `rollup` and `@rollup/*` packages.