### PR TITLE
chore: add "Dependabot CI" workflow for automatic dependency merging

### DIFF
--- a/.github/workflows/dependabot-ci.yml
+++ b/.github/workflows/dependabot-ci.yml
@@ -1,0 +1,18 @@
+name: Dependabot CI
+
+on:
+  pull_request:
+
+jobs:
+  automerge:
+    runs-on: ubuntu-latest
+
+    permissions:
+      pull-requests: write
+      contents: write
+
+    steps:
+      - uses: fastify/github-action-merge-dependabot@1b2ed42db8f9d81a46bac83adedfc03eb5149dff # v3.11.2
+        with:
+          use-github-auto-merge: true
+          merge-method: squash


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow to automate the merging of Dependabot pull requests. The workflow is designed to run on pull requests and uses the Fastify GitHub Action to automatically merge updates with a squash commit.

Automation improvements:

* Added a new workflow file `.github/workflows/dependabot-ci.yml` to enable automatic merging of Dependabot pull requests using the Fastify GitHub Action and the squash merge method.